### PR TITLE
initial the create_time to actual timestamp

### DIFF
--- a/alias/src/alias/agent/mock/mock_message_models.py
+++ b/alias/src/alias/agent/mock/mock_message_models.py
@@ -4,8 +4,9 @@ import uuid
 from enum import Enum
 from typing import Any, Optional, Literal
 from dataclasses import dataclass, field
-from pydantic import BaseModel, Field
 from datetime import datetime, timezone
+from pydantic import BaseModel, Field
+
 
 def _get_utc_now_iso():
     return datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
## 📝 PR Type

- [ ] Add new sample
- [x] Update existing sample
- [ ] Add new test cases
- [ ] Fix test failures
- [ ] Documentation/Configuration update

---

## 📚 Description

Resolve an issue where MockSession created MockMessage instances without a valid timestamp. The session now supplies a real (UTC) timestamp by default.

related issue: #108
---

## 🧪 Testing Validation

[Please explain how to validate the changes:
1. How to run the added/modified test cases?
2. Is integration testing with `agentscope` required?
3. Has code been formatted (e.g., `pre-commit`)?]

---

## ✅ Checklist

Please complete the following checks before submitting the PR:

- [ ] All sample code has been formatted with `pre-commit run --all-files`
- [ ] All new/modified test cases have passed (run `pytest tests/`)
- [ ] Test coverage has not decreased (if applicable)
- [ ] Sample code follows `agentscope` best practices (e.g., config management, logging)
- [ ] Related documentation in `agentscope-samples` has been updated (e.g., `README.md`)