### PR TITLE
fix(browser_use): fix signature of query_func in agentscope_browserus…

### DIFF
--- a/browser_use/browser_use_fullstack_runtime/backend/agentscope_browseruse_agent.py
+++ b/browser_use/browser_use_fullstack_runtime/backend/agentscope_browseruse_agent.py
@@ -101,7 +101,9 @@ def init():
         self,
         msgs,
         request: AgentRequest = None,
+        **kwargs,
     ):
+        # pylint: disable=unused-argument
         session_id = request.session_id
         user_id = request.user_id
 

--- a/browser_use/browser_use_fullstack_runtime/backend/requirements.txt
+++ b/browser_use/browser_use_fullstack_runtime/backend/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml>=6.0.2
 quart>=0.8.0
 quart-cors>=0.8.0
-agentscope-runtime>=1.0.0
+agentscope-runtime>=1.0.5
 agentscope[full]>=1.0.5
 openai>=2.8.1


### PR DESCRIPTION
## 📝 PR Type

- [ ] Add new sample
- [x] Update existing sample
- [ ] Add new test cases
- [ ] Fix test failures
- [ ] Documentation/Configuration update

---

## 📚 Description

This commit fixes a TypeError occurring when the AgentScope Runtime
calls query_func with a 'response' argument that was not defined in 
the function signature. 

Added **kwargs to query_func in agentscope_browseruse_agent.py to 
ensure compatibility with the latest agentscope-runtime.

---