### PR TITLE
Add Xquik MCP discovery sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ This is a repository that **brings together a variety of ready-to-run Python age
 ├── evaluation/
 │   └── ace_bench/                          # Benchmarks and evaluation tools
 │
+├── functionality/
+│   └── xquik_mcp_discovery/                # Read-only Xquik MCP tool discovery
+│
 ├── data_juicer_agent/                      # Data processing multi-agent system
 ├── tuner/                                  # Tune AgentScope applications using AgentScope Tuner
 │   ├── math_agent/                         # A quick start example for tuning
@@ -94,6 +97,7 @@ This is a repository that **brings together a variety of ready-to-run Python age
 |                         | conversational_agents/multiagent_conversation         | ✅               | ❌            | Multi-agent dialogue scenario                    |
 |                         | conversational_agents/multiagent_debate               | ✅               | ❌            | Agents engaging in debates                       |
 | **Evaluation**          | evaluation/ace_bench                                  | ✅               | ❌            | Benchmarks with ACE Bench                        |
+| **Functionality**       | functionality/xquik_mcp_discovery                     | ✅               | ❌            | Read-only MCP discovery for X workflows          |
 | **General AI Agent**               | alias/                                                | ✅               | ✅                      | Agent application running in sandbox to solve diverse real-world problems |
 | **Financial Trading**   | evotraders/                                           | ✅               | ❌            | Self-Evolving Multi-Agent Trading System         |
 

--- a/functionality/xquik_mcp_discovery/README.md
+++ b/functionality/xquik_mcp_discovery/README.md
@@ -6,8 +6,10 @@ This sample shows how to connect AgentScope's MCP client to Xquik's remote MCP s
 
 ```
 .
+├── __init__.py               # Enables package-based test discovery
 ├── README.md                 # Documentation
 ├── main.py                   # Entry point
+├── test_main.py              # Offline configuration and query tests
 └── requirements.txt          # Dependencies
 ```
 
@@ -17,7 +19,7 @@ The sample demonstrates a minimal AgentScope MCP integration for a hosted, authe
 
 - Connects to `https://xquik.com/mcp` with an `Authorization: Bearer <token>` header.
 - Enables only the read-only `explore` MCP tool.
-- Searches the Xquik API catalog for endpoint categories or summaries that match a query.
+- Searches the Xquik API catalogue for methods, paths, categories, or summaries that match a query.
 - Prints the matching endpoint method, path, category, summary, and free/paid status.
 
 No write or publish operations are executed. The sample does not call Xquik's live `xquik` execution tool.
@@ -41,11 +43,7 @@ pip install -r requirements.txt
 export XQUIK_API_KEY="your-api-key"
 ```
 
-Optional: override the MCP URL when testing a compatible endpoint.
-
-```bash
-export XQUIK_MCP_URL="https://xquik.com/mcp"
-```
+The sample fixes the remote URL to `https://xquik.com/mcp` so the API key is never sent to a configurable origin.
 
 ### Usage
 
@@ -63,9 +61,19 @@ python main.py monitors
 
 If no query is provided, the sample searches for `radar`.
 
+### Tests
+
+Run the offline tests from the repository root:
+
+```bash
+python -m unittest -v functionality.xquik_mcp_discovery.test_main
+```
+
 ## Features
 
 - Uses AgentScope's `MCPClient` and `HttpMCPConfig`.
 - Keeps the MCP connection stateless.
 - Restricts the remote server to the read-only `explore` tool.
 - Reads configuration only from environment variables.
+
+Xquik is an independent third-party service. It is not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

--- a/functionality/xquik_mcp_discovery/README.md
+++ b/functionality/xquik_mcp_discovery/README.md
@@ -1,0 +1,71 @@
+# Xquik MCP Discovery
+
+This sample shows how to connect AgentScope's MCP client to Xquik's remote MCP server and inspect X workflow endpoints with the read-only `explore` tool.
+
+## Sample Structure
+
+```
+.
+├── README.md                 # Documentation
+├── main.py                   # Entry point
+└── requirements.txt          # Dependencies
+```
+
+## Overview
+
+The sample demonstrates a minimal AgentScope MCP integration for a hosted, authenticated MCP server:
+
+- Connects to `https://xquik.com/mcp` with an `Authorization: Bearer <token>` header.
+- Enables only the read-only `explore` MCP tool.
+- Searches the Xquik API catalog for endpoint categories or summaries that match a query.
+- Prints the matching endpoint method, path, category, summary, and free/paid status.
+
+No write or publish operations are executed. The sample does not call Xquik's live `xquik` execution tool.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11 or higher
+- An Xquik API key
+
+### Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+### Setup
+
+```bash
+export XQUIK_API_KEY="your-api-key"
+```
+
+Optional: override the MCP URL when testing a compatible endpoint.
+
+```bash
+export XQUIK_MCP_URL="https://xquik.com/mcp"
+```
+
+### Usage
+
+Search for endpoints related to trends:
+
+```bash
+python main.py trends
+```
+
+Search for endpoints related to monitoring:
+
+```bash
+python main.py monitors
+```
+
+If no query is provided, the sample searches for `radar`.
+
+## Features
+
+- Uses AgentScope's `MCPClient` and `HttpMCPConfig`.
+- Keeps the MCP connection stateless.
+- Restricts the remote server to the read-only `explore` tool.
+- Reads configuration only from environment variables.

--- a/functionality/xquik_mcp_discovery/__init__.py
+++ b/functionality/xquik_mcp_discovery/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Xquik MCP discovery sample."""

--- a/functionality/xquik_mcp_discovery/main.py
+++ b/functionality/xquik_mcp_discovery/main.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Read-only AgentScope MCP discovery sample for Xquik."""
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+from agentscope.mcp import HttpMCPConfig, MCPClient
+
+
+DEFAULT_MCP_URL = "https://xquik.com/mcp"
+DEFAULT_QUERY = "radar"
+
+
+def _required_api_key() -> str:
+    api_key = os.environ.get("XQUIK_API_KEY", "").strip()
+    if api_key == "":
+        raise SystemExit("Set XQUIK_API_KEY before running this sample.")
+    return api_key
+
+
+def _query_from_args() -> str:
+    query = " ".join(sys.argv[1:]).strip().lower()
+    return query if query else DEFAULT_QUERY
+
+
+def _extract_text(result: Any) -> str:
+    content = getattr(result, "content", [])
+    parts = []
+    for item in content:
+        text = getattr(item, "text", None)
+        if text is not None:
+            parts.append(text)
+        else:
+            parts.append(str(item))
+    return "\n".join(parts)
+
+
+def _explore_code(query: str) -> str:
+    query_literal = json.dumps(query)
+    return f"""
+async () => spec.endpoints
+  .filter((endpoint) => {{
+    const haystack = `${{endpoint.method}} ${{endpoint.path}} ${{endpoint.category}} ${{endpoint.summary}}`.toLowerCase();
+    return haystack.includes({query_literal});
+  }})
+  .slice(0, 10)
+  .map((endpoint) => ({{
+    method: endpoint.method,
+    path: endpoint.path,
+    category: endpoint.category,
+    summary: endpoint.summary,
+    free: endpoint.free
+  }}))
+"""
+
+
+async def main() -> None:
+    client = MCPClient(
+        name="xquik",
+        is_stateful=False,
+        enable_tools=["explore"],
+        mcp_config=HttpMCPConfig(
+            type="http_mcp",
+            url=os.environ.get("XQUIK_MCP_URL", DEFAULT_MCP_URL),
+            headers={"Authorization": f"Bearer {_required_api_key()}"},
+        ),
+    )
+
+    explore = await client.get_tool("explore")
+    result = await explore(code=_explore_code(_query_from_args()))
+    print(_extract_text(result))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/functionality/xquik_mcp_discovery/main.py
+++ b/functionality/xquik_mcp_discovery/main.py
@@ -43,7 +43,12 @@ def _explore_code(query: str) -> str:
     return f"""
 async () => spec.endpoints
   .filter((endpoint) => {{
-    const haystack = `${{endpoint.method}} ${{endpoint.path}} ${{endpoint.category}} ${{endpoint.summary}}`.toLowerCase();
+    const haystack = [
+      endpoint.method,
+      endpoint.path,
+      endpoint.category,
+      endpoint.summary
+    ].join(" ").toLowerCase();
     return haystack.includes({query_literal});
   }})
   .slice(0, 10)
@@ -57,18 +62,21 @@ async () => spec.endpoints
 """
 
 
-async def main() -> None:
-    client = MCPClient(
+def _mcp_client(api_key: str) -> MCPClient:
+    return MCPClient(
         name="xquik",
         is_stateful=False,
         enable_tools=["explore"],
         mcp_config=HttpMCPConfig(
             type="http_mcp",
-            url=os.environ.get("XQUIK_MCP_URL", DEFAULT_MCP_URL),
-            headers={"Authorization": f"Bearer {_required_api_key()}"},
+            url=DEFAULT_MCP_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
         ),
     )
 
+
+async def main() -> None:
+    client = _mcp_client(_required_api_key())
     explore = await client.get_tool("explore")
     result = await explore(code=_explore_code(_query_from_args()))
     print(_extract_text(result))

--- a/functionality/xquik_mcp_discovery/requirements.txt
+++ b/functionality/xquik_mcp_discovery/requirements.txt
@@ -1,0 +1,1 @@
+agentscope>=1.0.12

--- a/functionality/xquik_mcp_discovery/test_main.py
+++ b/functionality/xquik_mcp_discovery/test_main.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Offline tests for the Xquik MCP discovery sample."""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+from .main import (
+    DEFAULT_MCP_URL,
+    DEFAULT_QUERY,
+    _explore_code,
+    _extract_text,
+    _mcp_client,
+    _query_from_args,
+    _required_api_key,
+)
+
+
+class XquikMCPDiscoveryTest(unittest.TestCase):
+    def test_required_api_key_is_trimmed(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"XQUIK_API_KEY": "  test-key  "},
+            clear=False,
+        ):
+            self.assertEqual(_required_api_key(), "test-key")
+
+    def test_required_api_key_rejects_empty_value(self) -> None:
+        with patch.dict(os.environ, {"XQUIK_API_KEY": ""}, clear=False):
+            with self.assertRaisesRegex(SystemExit, "Set XQUIK_API_KEY"):
+                _required_api_key()
+
+    def test_query_uses_arguments_or_default(self) -> None:
+        with patch.object(sys, "argv", ["main.py", "Twitter", "Trends"]):
+            self.assertEqual(_query_from_args(), "twitter trends")
+        with patch.object(sys, "argv", ["main.py"]):
+            self.assertEqual(_query_from_args(), DEFAULT_QUERY)
+
+    def test_explore_code_escapes_query_and_bounds_results(self) -> None:
+        query = 'trends"); throw new Error("unexpected")'
+        code = _explore_code(query)
+        self.assertIn(json.dumps(query), code)
+        self.assertIn(".slice(0, 10)", code)
+
+    def test_client_uses_fixed_origin_and_read_only_tool(self) -> None:
+        client = _mcp_client("test-key")
+        self.assertEqual(client.mcp_config.url, DEFAULT_MCP_URL)
+        self.assertEqual(
+            client.mcp_config.headers,
+            {"Authorization": "Bearer test-key"},
+        )
+        self.assertEqual(client.enable_tools, ["explore"])
+        self.assertFalse(client.is_stateful)
+
+    def test_extract_text_joins_text_and_fallback_content(self) -> None:
+        text_item = type("TextItem", (), {"text": "first"})()
+        fallback = type("Fallback", (), {"text": None})()
+        result = type("Result", (), {"content": [text_item, fallback]})()
+        self.assertEqual(
+            _extract_text(result),
+            f"first\n{fallback}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR Type

- [x] Add new sample
- [ ] Update existing sample
- [x] Add new test cases
- [ ] Fix test failures
- [x] Documentation/Configuration update

---

## Description

Closes #125.

Adds `functionality/xquik_mcp_discovery`, a small read-only AgentScope sample for exploring X / Twitter API routes through Xquik remote MCP server. It uses `MCPClient` and `HttpMCPConfig`, enables only the `explore` tool, searches current endpoint metadata, and requires no model-provider credentials.

The MCP origin is fixed to `https://xquik.com/mcp`. The bearer key cannot be redirected to an environment-configured host. Six offline tests cover that boundary, the read-only tool allow-list, API-key handling, default and explicit queries, JavaScript string escaping, result limits, and output conversion.

---

## Testing Validation

1. `pre-commit run --all-files` passed every repository hook, including mypy, Black, Flake8, Pylint, ESLint, Stylelint, and Prettier.
2. `python -m unittest -v functionality.xquik_mcp_discovery.test_main` passed 6 offline tests.
3. `python -m py_compile` passed for the package, sample, and tests.
4. `uv pip check` passed with AgentScope 2.0.6 on Python 3.11.
5. The current public MCP discovery document returned HTTP 200 and identifies `https://xquik.com/mcp` as the streamable HTTP endpoint. The endpoint returned 401 without authentication, as expected.

A live tool call was not run because it requires an Xquik API key. The tests make no network requests.

---

## Checklist

- [x] All sample code has been formatted with `pre-commit run --all-files`.
- [x] All new tests pass.
- [x] Test coverage has not decreased.
- [x] Sample code follows AgentScope configuration and MCP patterns.
- [x] The root and sample documentation are updated.
- [x] The sample installs independently through its `requirements.txt`.

## Security and Independence

- Only the read-only `explore` tool is enabled.
- The sample never calls the live `xquik` execution tool.
- The fixed HTTPS origin prevents bearer-key forwarding to a configurable host.
- Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

Codex assisted with the current validation and repair. I reviewed the final implementation and test evidence.